### PR TITLE
Fix test and update last_run time after every import

### DIFF
--- a/import_new_files.py
+++ b/import_new_files.py
@@ -57,18 +57,19 @@ def import_new_files(args):
             )
             print(f"importing {s3_path}")
             get_psql_results(args)
-        new_last_run_parts = files[-1][0].split('-')
-        new_last_run = '%s %s' % ('-'.join(new_last_run_parts[0:3]), ':'.join(new_last_run_parts[3:6]))
-        args.DB_QUERY = """
-        UPDATE tech.script_last_run
-        SET last_run = %s
-        WHERE script = %s
-        """
-        args.DB_VALUES = (
-            new_last_run,
-            args.LAST_RUN_SCRIPT
-        )
-        get_psql_results(args)
+            # Update last_run after every file load
+            new_last_run_parts = file[0].split('-')
+            new_last_run = '%s %s' % ('-'.join(new_last_run_parts[0:3]), ':'.join(new_last_run_parts[3:6]))
+            args.DB_QUERY = """
+            UPDATE tech.script_last_run
+            SET last_run = %s
+            WHERE script = %s
+            """
+            args.DB_VALUES = (
+                new_last_run,
+                args.LAST_RUN_SCRIPT
+            )
+            get_psql_results(args)
     else:
         new_last_run = last_run.strftime('%Y-%m-%d %H:%M:%S')
     return {'imports': len(files), 'last': new_last_run}

--- a/test_import_new_files.py
+++ b/test_import_new_files.py
@@ -36,6 +36,8 @@ class Test():
             'DB_USER': 'mock',
             'DB_PASS': 'mock',
             'DB_NAME': 'mock',
+            'DB_TABLE': 'mock',
+            'LAST_RUN_SCRIPT': '2020-02-01-01 00:00:00'
         }
         args = Struct(**args)
         # Nothing new to import.


### PR DESCRIPTION
If the importer is unable to complete, it won't know if it made some partial progress or no progress.  It's still not perfect (could be killed in between import and last_run update) but will result in fewer duplicates.