### PR TITLE
added a check for nonzero file size

### DIFF
--- a/s3_file_list.py
+++ b/s3_file_list.py
@@ -19,7 +19,7 @@ def s3_file_list(args) -> list:
         aws_secret_access_key=args.AWS_SECRET_KEY,
     )
     object_list = s3_client.list_objects(Bucket=args.S3_BUCKET)
-    file_list = [file.get('Key') for file in object_list.get('Contents', [])]
+    file_list = [file.get('Key') for file in object_list.get('Contents', []) if file.get('Size') > 0]
     # We get at most 1000 results at a time
     while len(object_list.get('Contents', []))==1000:
         print("Over 1000 found, getting next 1000")
@@ -27,7 +27,7 @@ def s3_file_list(args) -> list:
         print(f"Marker: {marker}")
         object_list = s3_client.list_objects(Bucket=args.S3_BUCKET, Marker=marker)
         print(f"Found {len(object_list)} more objects")
-        file_list = file_list + [file.get('Key') for file in object_list.get('Contents', [])]
+        file_list = file_list + [file.get('Key') for file in object_list.get('Contents', []) if file.get('Size') > 0]
     return file_list
 
 


### PR DESCRIPTION
Vote.org always creates a csv file every two hours, but when there's no new data the file size is zero. We should skip these empty files instead of trying to import them. And then we won't be Cloudwatch alerting on failed attempts to import empty files.